### PR TITLE
dynamically link lib

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,6 +29,7 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
     });
+    lib.linkage = .dynamic;
 
     setupOdbcDependencies(lib);
     b.installArtifact(lib);


### PR DESCRIPTION
Allows `ODBC` library to be overridden with common environment variables e.g. `LD_LIBRARY_PATH`

<img width="1025" alt="Screenshot 2024-02-13 at 8 46 54 PM" src="https://github.com/mjoerussell/zig-odbc/assets/680789/71c10ffa-8351-4ee1-a837-2fd8b4e31d41">
